### PR TITLE
feat: allow video banners

### DIFF
--- a/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
+++ b/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
@@ -1,46 +1,60 @@
 package com.adgrowth.adserver.views;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.adgrowth.internal.http.AdRequest;
 import com.adgrowth.adserver.R;
 import com.adgrowth.adserver.enums.AdOrientation;
+import com.adgrowth.adserver.enums.AdSizeType;
 import com.adgrowth.adserver.exceptions.AdRequestException;
 import com.adgrowth.internal.entities.Ad;
-import com.adgrowth.adserver.enums.AdSizeType;
+import com.adgrowth.internal.enums.AdMediaType;
 import com.adgrowth.internal.enums.AdType;
 import com.adgrowth.internal.helpers.AdUriHelpers;
+import com.adgrowth.internal.helpers.FullScreenEventManager;
+import com.adgrowth.internal.http.AdRequest;
 import com.adgrowth.internal.interfaces.BaseAdListener;
+import com.adgrowth.internal.interfaces.FullScreenListener;
 import com.adgrowth.internal.views.AdImage;
+import com.adgrowth.internal.views.AdPlayer;
 
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 
 
-public class AdView extends ViewGroup implements AdImage.Listener {
+public class AdView extends ViewGroup implements Application.ActivityLifecycleCallbacks, AdImage.Listener, AdPlayer.Listener, FullScreenListener {
     private static final int AFTER_ERROR_REFRESH_RATE = 10;
+    private static final int SDK_NOT_INITIALIZED_RETRY_TIME = 3;
     private AdRequest mAdRequest;
     private Activity mContext;
-    AdImage mAdImage;
+    AdImage mImage;
+    AdPlayer mPlayer;
     private Listener mListener;
-    private Timer mRefreshTimer;
     private Ad mAd;
     private Boolean mFailedToLoad = false;
     private Boolean mAdIsReady = false;
-    boolean mRefreshCountStarted = false;
-    private final AdOrientation mOrientation;
-    private final String mUnitId;
-    private final AdSizeType mSize;
+    protected Timer mAdDisplayTimer = new Timer();
+    protected Integer mCurrentAdDisplayTime = 0;
+    protected Integer mTimeToRefresh = 30;
+    private AdOrientation mOrientation;
+    private String mUnitId;
+    private AdSizeType mSize;
 
     private final View.OnClickListener onAdClickListener = view -> {
         if (mAd == null) {
@@ -51,34 +65,47 @@ public class AdView extends ViewGroup implements AdImage.Listener {
         AdUriHelpers.openUrl(mContext, mAd.getActionUrl(), mAd.getIpAddress());
 
         if (mListener != null) mContext.runOnUiThread(() -> mListener.onClicked());
+
     };
 
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        stopRefreshCountdown();
+        stopAdStartedTimer();
     }
 
     public AdView(Context context, String unitId, AdSizeType size, AdOrientation orientation) {
         super(context);
-        this.mContext = (Activity) context;
         this.mUnitId = unitId;
         this.mSize = size;
         this.mOrientation = orientation;
         init();
     }
 
-    public AdView(Context context, @Nullable AttributeSet attrs) {
+    public AdView(Context context) {
+        super(context);
+        this.mUnitId = "";
+        this.mSize = AdSizeType.BANNER;
+        this.mOrientation = AdOrientation.LANDSCAPE;
+        init();
+    }
+
+    public AdView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        getAdAttributes(context, attrs);
+        init();
+    }
+
+    public AdView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        getAdAttributes(context, attrs);
+        init();
+    }
+
+    public AdView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        this.mContext = (Activity) context;
-
-        TypedArray attributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AdView, 0, 0);
-
-        this.mOrientation = attributes.getInteger(R.styleable.AdView_orientation, 0) == 1 ? AdOrientation.PORTRAIT : AdOrientation.LANDSCAPE;
-        this.mSize = AdSizeType.values()[(attributes.getInteger(R.styleable.AdView_size, 0))];
-        this.mUnitId = attributes.getString(R.styleable.AdView_unit_id);
-
+        getAdAttributes(context, attrs);
         init();
     }
 
@@ -140,19 +167,39 @@ public class AdView extends ViewGroup implements AdImage.Listener {
         this.mListener = listener;
     }
 
+    void getAdAttributes(Context context, AttributeSet attrs) {
+        TypedArray attributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AdView, 0, 0);
+
+        this.mOrientation = attributes.getInteger(R.styleable.AdView_orientation, 0) == 1 ? AdOrientation.PORTRAIT : AdOrientation.LANDSCAPE;
+        this.mSize = AdSizeType.values()[(attributes.getInteger(R.styleable.AdView_size, 0))];
+        this.mUnitId = attributes.getString(R.styleable.AdView_unit_id);
+    }
 
     void init() {
+        if (mUnitId == null || mUnitId.equals("")) {
+            if (isInEditMode()) showErrorOnPreview();
+            else throw new IllegalArgumentException("You must provide an unit_id for AdView");
+        }
+        // this prevent preview problems on android studio
+        if (isInEditMode()) return;
 
-        if (mUnitId == null || mUnitId.equals(""))
-            throw new RuntimeException("You must provide an unit_id for AdView");
+        mContext = (Activity) getContext();
 
-
-        this.setOnClickListener(onAdClickListener);
+        FullScreenEventManager.registerFullScreenListener(this);
+        setOnClickListener(onAdClickListener);
+        mContext.getApplication().registerActivityLifecycleCallbacks(AdView.this);
         mAdRequest = new AdRequest();
-
         loadAd();
     }
 
+    @SuppressLint("SetTextI18n")
+    void showErrorOnPreview() {
+        this.setBackgroundColor(Color.parseColor("#FF0000"));
+        TextView text = new TextView(getContext());
+        text.setTextColor(Color.parseColor("#FFFFFF"));
+        text.setText("MISSING UNIT_ID");
+        addView(text);
+    }
 
     private void loadAd() {
         new Thread(() -> {
@@ -166,16 +213,20 @@ public class AdView extends ViewGroup implements AdImage.Listener {
 
                 mAd = mAdRequest.getAd(mUnitId, options);
 
-                if (mAd.getType() != AdType.BANNER) {
+                if (mAd.getType() != AdType.BANNER)
                     throw new AdRequestException(AdRequestException.UNIT_ID_MISMATCHED_AD_TYPE);
-                }
+
                 presentAd(mAd);
 
             } catch (AdRequestException e) {
                 mFailedToLoad = true;
-                startRefreshCountdown(AFTER_ERROR_REFRESH_RATE);
-                if (mListener != null)
-                    mContext.runOnUiThread(() -> mListener.onFailedToLoad(e));
+                if (Objects.equals(e.getCode(), AdRequestException.SDK_NOT_INITIALIZED)) {
+                    mTimeToRefresh = SDK_NOT_INITIALIZED_RETRY_TIME;
+                } else {
+                    mTimeToRefresh = AFTER_ERROR_REFRESH_RATE;
+                }
+                startAdDisplayTimer();
+                if (mListener != null) mContext.runOnUiThread(() -> mListener.onFailedToLoad(e));
             }
 
         }).start();
@@ -184,72 +235,113 @@ public class AdView extends ViewGroup implements AdImage.Listener {
     void presentAd(Ad ad) {
 
         mContext.runOnUiThread(() -> {
-            this.mAdImage = new AdImage(mContext, ad.getMediaUrl(), this);
-            mAdImage.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-            mAdImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
-            super.addView(mAdImage);
+            mCurrentAdDisplayTime = 0;
+            if (ad.getMediaType() == AdMediaType.IMAGE) {
+                this.mImage = new AdImage(mContext, ad.getMediaUrl(), this);
+                mImage.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+                mImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                super.addView(mImage);
+                return;
+            }
+
+            this.mPlayer = new AdPlayer(mContext, ad.getMediaUrl(), this);
+            mPlayer.setScaleType(AdPlayer.ScaleType.FIT_CENTER);
+            mPlayer.setMuted(true);
+            super.addView(mPlayer);
+
+
         });
     }
 
     public void reload() {
-
         refreshAd();
     }
 
     private void refreshAd() {
         if (mAd != null) mAd = null;
-        stopRefreshCountdown();
-        removeView(mAdImage);
+        stopAdStartedTimer();
+        mCurrentAdDisplayTime = 0;
+        if (mImage != null) {
+            removeView(mImage);
+            mImage = null;
+        }
+        if (mPlayer != null) {
+            removeView(mPlayer);
+            mPlayer.release();
+            mPlayer = null;
+        }
         loadAd();
     }
 
-    private void stopRefreshCountdown() {
-        if (mRefreshTimer != null) {
-            mRefreshCountStarted = false;
-            mRefreshTimer.cancel();
-            mRefreshTimer = null;
+    private void onDisplayTimeChanged(double adStartedTime) {
+        if (adStartedTime >= mTimeToRefresh) {
+            refreshAd();
         }
-
     }
 
-    private void startRefreshCountdown(Integer refreshRate) {
-        mRefreshTimer = new Timer();
+    public void startAdDisplayTimer() {
+        if (mAdDisplayTimer != null) mAdDisplayTimer.cancel();
+        if (mTimeToRefresh == Ad.DISABLED_REFRESH_RATE) return;
 
-        // 0 = disabled
-        if (refreshRate == 0)
-            return;
+        mAdDisplayTimer = new Timer();
 
         TimerTask task = new TimerTask() {
             @Override
             public void run() {
-                mContext.runOnUiThread(() -> refreshAd());
+                mCurrentAdDisplayTime++;
+                mContext.runOnUiThread(() -> onDisplayTimeChanged(mCurrentAdDisplayTime));
             }
         };
 
-        mRefreshTimer.scheduleAtFixedRate(task, refreshRate * 1000, refreshRate * 1000);
-        mRefreshCountStarted = true;
+        mAdDisplayTimer.scheduleAtFixedRate(task, 1000, 1000);
+    }
+
+    public void stopAdStartedTimer() {
+        if (mAdDisplayTimer != null) {
+            mAdDisplayTimer.cancel();
+            mAdDisplayTimer = null;
+        }
+    }
+
+    private Integer getAdDisplayTime(Integer refreshRate) {
+        if (refreshRate == Ad.AUTO_REFRESH_RATE) {
+            if (mAd.getMediaType() == AdMediaType.VIDEO) {
+                return mPlayer.getAdDuration();
+            }
+            if (mAd.getMediaType() == AdMediaType.IMAGE) {
+                return Ad.DEFAULT_REFRESH_RATE;
+            }
+
+        }
+
+        // 0 or 30-150
+        return refreshRate;
+
     }
 
     @Override
     public void onImageReady() {
         mAdIsReady = true;
+        mTimeToRefresh = getAdDisplayTime(mAd.getRefreshRate());
+
         if (mListener != null) {
             mContext.runOnUiThread(() -> {
                 mListener.onLoad(this);
                 mListener.onImpression();
             });
-
-            if (!mRefreshCountStarted)
-                startRefreshCountdown(mAd.getRefreshRate());
-
         }
-            mAdRequest.sendImpression(mContext, mAd);
+
+        startAdDisplayTimer();
+        mAdRequest.sendImpression(mContext, mAd);
     }
 
     @Override
     public void onImageError() {
         mFailedToLoad = true;
-        startRefreshCountdown(AFTER_ERROR_REFRESH_RATE);
+        mTimeToRefresh = AFTER_ERROR_REFRESH_RATE;
+
+        startAdDisplayTimer();
+
         if (mListener != null)
             mContext.runOnUiThread(() -> mListener.onFailedToLoad(new AdRequestException(AdRequestException.NETWORK_ERROR)));
     }
@@ -266,6 +358,110 @@ public class AdView extends ViewGroup implements AdImage.Listener {
         return mOrientation;
     }
 
+    void pauseAd() {
+        stopAdStartedTimer();
+        if (mPlayer != null && mAd.getMediaType() == AdMediaType.VIDEO) mPlayer.pause();
+    }
+
+    void resumeAd() {
+        startAdDisplayTimer();
+        if (mPlayer != null && mAd.getMediaType() == AdMediaType.VIDEO) mPlayer.play();
+    }
+
+    @Override
+    public void onVideoProgressChanged(double position, double total) {
+        mCurrentAdDisplayTime = (int) position;
+    }
+
+    private boolean isCurrentActivity(Activity activity) {
+        return mContext.equals(activity);
+    }
+
+    @Override
+    public void onVideoReady(int videoDuration) {
+        mTimeToRefresh = getAdDisplayTime(mAd.getRefreshRate());
+
+        if (mListener != null) {
+            mContext.runOnUiThread(() -> {
+                mListener.onLoad(this);
+                mListener.onImpression();
+            });
+        }
+
+        mPlayer.play();
+        startAdDisplayTimer();
+        mAdRequest.sendImpression(mContext, mAd);
+    }
+
+    @Override
+    public void onVideoFinished() {
+        refreshAd();
+    }
+
+    @Override
+    public void onVideoError() {
+        if (mListener != null)
+            mListener.onFailedToLoad(new AdRequestException(AdRequestException.PLAYBACK_ERROR));
+    }
+
+    @Override
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle bundle) {
+    }
+
+    @Override
+    public void onActivityStarted(@NonNull Activity activity) {
+    }
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
+        if (isCurrentActivity(activity)) {
+            resumeAd();
+        }
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity activity) {
+        if (isCurrentActivity(activity)) {
+            pauseAd();
+        }
+    }
+
+    @Override
+    public void onActivityStopped(@NonNull Activity activity) {
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle bundle) {
+    }
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity activity) {
+        if (isCurrentActivity(activity)) {
+            stopAdStartedTimer();
+            FullScreenEventManager.unregisterFullScreenListener(this);
+
+            if (mContext != null) {
+                mContext.getApplication().unregisterActivityLifecycleCallbacks(AdView.this);
+            }
+
+            if (mPlayer != null) {
+                mPlayer.release();
+                mPlayer = null;
+            }
+        }
+    }
+
+    @Override
+    public void onFullScreenShown(int ignored) {
+        pauseAd();
+    }
+
+    @Override
+    public void onFullScreenDismissed() {
+        resumeAd();
+    }
+
     public interface Listener extends BaseAdListener<AdView> {
     }
+
 }


### PR DESCRIPTION
### Allow video on banner ads

- Adjust AdPlayer for accept scale type for FIT and CROP video
- fix AdPlayer timers for video progress
- pause banners when a full screen ad was called
- fix preview on Android Studio IDE
- add visual alert of missing required properties (unit_id)
![Captura de Tela 2023-09-21 às 10 57 25](https://github.com/Ad-Growth/ad-sdk-android/assets/78423625/c2869fe2-021b-44bf-a9c3-8ae1f2f484d9)
