### PR TITLE
fix(adview): add missing unregister for events when adview has destroyed

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Adserver Android SDK
+Ad SDK Android

--- a/ad_library/build.gradle
+++ b/ad_library/build.gradle
@@ -6,14 +6,14 @@ plugins {
 
 android {
     namespace 'com.adgrowth.adserver'
-    compileSdk 28
+    compileSdk 34
     compileOptions {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         minSdk 24
         //noinspection ExpiredTargetSdkVersion
-        targetSdk 28
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -35,8 +35,8 @@ android {
 
 dependencies {
     api 'com.github.bumptech.glide:glide:4.15.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    api 'androidx.constraintlayout:constraintlayout:2.1.4'
+    api 'com.google.android.gms:play-services-ads-identifier:18.0.1'
 }
 
 afterEvaluate {

--- a/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
+++ b/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
@@ -72,6 +72,10 @@ public class AdView extends ViewGroup implements Application.ActivityLifecycleCa
         super.onDetachedFromWindow();
 
         stopAdStartedTimer();
+        FullScreenEventManager.unregisterFullScreenListener(this);
+
+        mContext.getApplication().unregisterActivityLifecycleCallbacks(AdView.this);
+
     }
 
     public AdView(Context context, String unitId, AdSizeType size, AdOrientation orientation) {
@@ -273,6 +277,7 @@ public class AdView extends ViewGroup implements Application.ActivityLifecycleCa
     }
 
     private void onDisplayTimeChanged(double adStartedTime) {
+        System.out.println("CHANGED TIME: " + adStartedTime);
         if (adStartedTime >= mTimeToRefresh) {
             refreshAd();
         }

--- a/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
+++ b/ad_library/src/main/java/com/adgrowth/adserver/views/AdView.java
@@ -277,7 +277,6 @@ public class AdView extends ViewGroup implements Application.ActivityLifecycleCa
     }
 
     private void onDisplayTimeChanged(double adStartedTime) {
-        System.out.println("CHANGED TIME: " + adStartedTime);
         if (adStartedTime >= mTimeToRefresh) {
             refreshAd();
         }

--- a/ad_library/src/main/java/com/adgrowth/internal/entities/Ad.java
+++ b/ad_library/src/main/java/com/adgrowth/internal/entities/Ad.java
@@ -4,6 +4,7 @@ package com.adgrowth.internal.entities;
 import androidx.annotation.NonNull;
 
 import com.adgrowth.adserver.entities.RewardItem;
+import com.adgrowth.adserver.enums.AdOrientation;
 import com.adgrowth.internal.enums.AdMediaType;
 import com.adgrowth.internal.enums.AdType;
 import com.adgrowth.internal.helpers.JSONHelper;
@@ -32,6 +33,7 @@ public class Ad {
     private final String mPostMediaUrl;
     private final AdMediaType mMediaType;
     private boolean mConsumed = false;
+    private AdOrientation mOrientation;
 
 
     public Ad(JSONObject json) {
@@ -46,6 +48,7 @@ public class Ad {
         this.mActionUrl = JSONHelper.safeGetString(advert, "action_url");
         this.mImpressionUrl = JSONHelper.safeGetString(advert, "impression_url");
         this.mPostMediaUrl = JSONHelper.safeGetString(advert, "post_media_url");
+        this.mOrientation = AdOrientation.valueOf(JSONHelper.safeGetString(advert, "orientation"));
 
         // meta
         this.mRewardItem = JSONHelper.safeGetString(meta, "reward_item", DEFAULT_REWARD_ITEM);
@@ -125,5 +128,9 @@ public class Ad {
 
     public String getImpressionUrl() {
         return this.mImpressionUrl;
+    }
+
+    public AdOrientation getOrientation() {
+        return mOrientation;
     }
 }

--- a/ad_library/src/main/java/com/adgrowth/internal/helpers/ScreenHelpers.java
+++ b/ad_library/src/main/java/com/adgrowth/internal/helpers/ScreenHelpers.java
@@ -1,12 +1,21 @@
 package com.adgrowth.internal.helpers;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 
+import com.adgrowth.adserver.enums.AdOrientation;
+
 public class ScreenHelpers {
-    public static String getOrientation(Context context) {
+    public static AdOrientation getOrientation(Context context) {
         int orientation = context.getResources().getConfiguration().orientation;
 
-        return orientation == Configuration.ORIENTATION_LANDSCAPE ? "LANDSCAPE" : "PORTRAIT";
+        return orientation == Configuration.ORIENTATION_LANDSCAPE ? AdOrientation.LANDSCAPE : AdOrientation.PORTRAIT;
+    }
+
+    public static void setOrientation(Activity context, AdOrientation orientation) {
+        context.setRequestedOrientation(orientation == AdOrientation.LANDSCAPE ? ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE : ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+
     }
 }

--- a/ad_library/src/main/java/com/adgrowth/internal/http/AdRequest.java
+++ b/ad_library/src/main/java/com/adgrowth/internal/http/AdRequest.java
@@ -14,6 +14,7 @@ import com.adgrowth.internal.entities.Ad;
 import com.adgrowth.internal.helpers.IOErrorHandler;
 import com.adgrowth.internal.helpers.AdUriHelpers;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
@@ -67,7 +68,13 @@ public class AdRequest {
 
         try {
             JSONObject response = mApiClient.get("/adserver/api/adverts/search", params);
+            if (params.containsKey("orientation")) {
+                try {
+                    response.getJSONObject("advert").put("orientation", params.get("orientation"));
+                } catch (JSONException ignore) {
 
+                }
+            }
             return new Ad(response);
         } catch (APIIOException e) {
             throw IOErrorHandler.handle(e);

--- a/ad_library/src/main/java/com/adgrowth/internal/views/AdDialog.java
+++ b/ad_library/src/main/java/com/adgrowth/internal/views/AdDialog.java
@@ -1,5 +1,6 @@
 package com.adgrowth.internal.views;
 
+
 import android.app.Dialog;
 import android.content.Context;
 import android.view.Gravity;
@@ -7,6 +8,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
+import android.view.animation.Animation;
+import android.view.animation.DecelerateInterpolator;
+import android.view.animation.LinearInterpolator;
+import android.view.animation.Transformation;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -22,13 +27,11 @@ public class AdDialog extends Dialog {
 
     private final ProgressBar mProgressBar;
     private final ImageView mCloseBtn;
-
     private final TextView mCloseTextView;
 
 
     public AdDialog(@NonNull Context context) {
         super(context, android.R.style.Theme_Translucent_NoTitleBar);
-
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.activity_fit_content);
@@ -51,9 +54,10 @@ public class AdDialog extends Dialog {
     }
 
     public void setVideoProgress(int progress) {
-        if (mProgressBar.getVisibility() != View.VISIBLE)
-            mProgressBar.setVisibility(View.VISIBLE);
-        mProgressBar.setProgress(progress);
+        if (mProgressBar.getVisibility() != View.VISIBLE) mProgressBar.setVisibility(View.VISIBLE);
+
+        mProgressBar.setProgress(progress, true);
+
     }
 
     public void enableCloseButton() {
@@ -64,21 +68,15 @@ public class AdDialog extends Dialog {
     public boolean isCloseButtonEnabled() {
         return mCloseBtn.isEnabled();
     }
-
     public void showButtonText() {
         mCloseTextView.setVisibility(View.VISIBLE);
     }
-
-    public void hideButtonText() {
-        mCloseTextView.setVisibility(View.GONE);
-    }
-
-
     public void hideProgressBar() {
         mProgressBar.setVisibility(View.GONE);
     }
-
     public void setButtonLabelText(String text) {
         mCloseTextView.setText(text);
     }
+
+
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "Adserver Android SDK"
+rootProject.name = "Ad SDK Android"
 include ':ad_library'


### PR DESCRIPTION
- unregister from activity and full screen ad events when adview is destroyed
- save ad orientation on request
- handle ad orientation on show
- enable progressBar animations